### PR TITLE
Fix link out of package error

### DIFF
--- a/deezer.sh
+++ b/deezer.sh
@@ -92,7 +92,9 @@ build()
     # Add start in tray cli option (https://github.com/SibrenVasse/deezer/pull/12)
     patch --forward --strip=1 --input="../../../../start-hidden-on-tray.patch"
 
-    cd .. && asar pack "app" "app.asar"
+    cd .. && \
+    rm app/node_modules/abstract-socket/build/node_gyp_bins/python3 || true && \
+    asar pack "app" "app.asar"
 
     [ ! -d "$pkgdir" ] && mkdir -p "$pkgdir"
     [ ! -d "$pkgdir/DEBIAN/" ] && sudo mkdir -p "$pkgdir/DEBIAN/"


### PR DESCRIPTION
Note, you might not want the || true after the rm of the python binary link. I think it is safer in case upstream fixes the issue by removing this link themselves, but if the path to this file change the build will attempt to pack the app even though the link is not removed (and this issue will resurface). Your call.

deeze.sh -b error out with:
/usr/local/lib/node_modules/asar/lib/filesystem.js:101
      throw new Error(`${p}: file "${link}" links out of the package`)
            ^

Error: app/node_modules/abstract-socket/build/node_gyp_bins/python3: file "../../../../../../../../../../../usr/bin/python3.10" links out of the package
    at Filesystem.insertLink (/usr/local/lib/node_modules/asar/lib/filesystem.js:101:13)
    at handleFile (/usr/local/lib/node_modules/asar/lib/asar.js:132:20)
    at next (/usr/local/lib/node_modules/asar/lib/asar.js:148:11)
    at next (/usr/local/lib/node_modules/asar/lib/asar.js:149:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

workaround it by removing this symlink before calling "asar pack app app.asar".

The upstream issue is not fixed yet:
https://github.com/nodejs/node-gyp/issues/2713
"node_gyp_bins causes build failures in downstream packages"